### PR TITLE
Fixes and Enhancements

### DIFF
--- a/jquery-treetable.js
+++ b/jquery-treetable.js
@@ -1,146 +1,157 @@
 jQuery.fn.extend({
-	treetable: function() {
-		var $table = $(this);
-		$table.addClass("tt-table");
+    treetable: function () {
 
-		var $items = $table.find("div.tt");
-		var index = {};
-		var items = [];
+        //collection of all the tables selected
+        var $tables = $(this);
 
-		// add items to index
-		$items.each(function (i, el) {
-			var $el = $(el);
-			var id = $el.data('tt-id');
-			var parent = $el.data('tt-parent');
-			if(parent === '') {
-				parent = undefined;
-			}
+        //loop through each table
+        for (i = 0; i < $tables.length; i++) {
+            var $table = $($tables[i]);
 
-			var item = {
-				id: id,
-				parent: parent,
-				children: [],
-				el: $el,
-				left: 0,
-				width: $el.width() + 12
-			};
+            //don't paint the tt if the table has already been painted or it's invisible
+            if (!$table.hasClass("tt-table") && $table.is(":visible")) {
 
-			index[id] = item;
-			items.push(item);
-		});
+                $table.addClass("tt-table");
 
-		// make a graph from parent relations
-		items.forEach(function (item) {
-			if (item.parent !== undefined) {
-				item.parent = index[item.parent];
-				item.parent.children.push(item);
-			}
-		});
+                var $items = $table.find("div.tt");
 
-		// pad items
-		items.forEach(function (item) {
+                var index = {};
+                var items = [];
 
-			item.left = 0;
-			if (item.parent !== undefined) {
-				item.left = item.parent.left + item.parent.width;
-			}
-		});
+                // add items to index
+                $items.each(function (i, el) {
+                    var $el = $(el);
+                    var id = $el.data('tt-id');
+                    var parent = $el.data('tt-parent');
+                    if (parent === '') {
+                        parent = undefined;
+                    }
 
-		// position items
-		items.forEach(function (item) {
-			//console.log(el.left);
-			item.el.css("left", item.left);
-		});
+                    var item = {
+                        id: id,
+                        parent: parent,
+                        children: [],
+                        el: $el,
+                        left: 0,
+                        width: $el.width() + 12
+                    };
 
-		// wrap contents
-		items.forEach(function (item) {
-			item.el.html('<div class="content">' + item.el.html() + '</div>');
-		});
-
-		// add parent classes
-		items.forEach(function (item) {
-			if (item.children.length > 0) {
-				item.el.addClass("tt-parent");
-				item.showChildren = true;
-			}
-		});
-
-
-        function drawLines()
-        {
-            // draw lines
-            items.forEach(function (item) {
-
-                if (item.parent === undefined) {
-                    return;
-                }
-
-                var childPos = item.el.position();
-                var parent = item.parent;
-
-                var parentPos = parent.el.position();
-                var height = childPos.top - parentPos.top;
-                var width = item.left - parent.left;
-                var left = parent.left - item.left + (parent.width / 2);
-
-                item.el.children('div.tail').first().remove();
-
-                var $tail = $('<div class="tail"></div>').css({
-                    height: height,
-                    width: width,
-                    left: left
+                    index[id] = item;
+                    items.push(item);
                 });
 
-                item.el.prepend($tail);
-            });
+                // make a graph from parent relations
+                items.forEach(function (item) {
+                    if (item.parent !== undefined) {
+                        item.parent = index[item.parent];
+                        item.parent.children.push(item);
+                    }
+                });
+
+                // pad items
+                items.forEach(function (item) {
+                    item.left = 0;
+                    if (item.parent !== undefined) {
+                        item.left = item.parent.left + item.parent.width;
+                    }
+                });
+
+                // position items
+                items.forEach(function (item) {
+                    //console.log(el.left);
+                    item.el.css("left", item.left);
+                });
+
+                // wrap contents
+                items.forEach(function (item) {
+                    item.el.html('<div class="content">' + item.el.html() + '</div>');
+                    var test = 0;
+                });
+
+                // add parent classes
+                items.forEach(function (item) {
+                    if (item.children.length > 0) {
+                        item.el.addClass("tt-parent");
+                        item.showChildren = true;
+                    }
+                });
+
+                function drawLines() {
+                    // draw lines
+                    items.forEach(function (item) {
+
+                        if (item.parent === undefined) {
+                            return;
+                        }
+
+                        var childPos = item.el.position();
+                        var parent = item.parent;
+
+                        var parentPos = parent.el.position();
+                        var height = childPos.top - parentPos.top;
+                        var width = item.left - parent.left;
+                        var left = parent.left - item.left + (parent.width / 2);
+
+                        item.el.children('div.tail').first().remove();
+
+                        var $tail = $('<div class="tail"></div>').css({
+                            height: height,
+                            width: width,
+                            left: left
+                        });
+
+                        item.el.prepend($tail);
+                    });
+                }
+
+                drawLines();
+
+                // handle click event
+                $table.on("click", "div.tt div.content", function (e) {
+
+                    var $el = $(e.currentTarget).closest(".tt");
+                    var $tr = $el.closest("tr");
+                    var id = $el.data('tt-id');
+                    var item = index[id];
+
+                    if (item.showChildren === true) {
+                        // hide all children
+                        item.showChildren = false;
+
+                        function hide(parentId) {
+                            var item = index[parentId];
+                            item.children.forEach(function (child) {
+                                if (child.showChildren !== undefined) {
+                                    child.showChildren = false;
+                                }
+
+                                $(child.el).closest("tr").addClass("tt-hide");
+                                hide(child.id);
+                            });
+                        }
+
+                        hide(id);
+                        drawLines();
+                    }
+                    else {
+                        // show direct children
+                        item.showChildren = true;
+                        item.children.forEach(function (child) {
+                            $(child.el).closest("tr").removeClass("tt-hide");
+                        });
+                        drawLines();
+                    }
+                });
+            };
         }
-        drawLines();
 
+        // initially hide all children - here we should provide an option to initially open or closed
+        //items.forEach(function (item) {
 
-		// handle click event
-		$table.on("click", "div.tt div.content", function (e) {
+        //    if (item.parent === undefined && item.children.length > 0) {
+        //        item.el.find(".content").click();
+        //    }
+        //});
 
-			var $el = $(e.currentTarget).closest(".tt");
-			var $tr = $el.closest("tr");
-			var id = $el.data('tt-id');
-			var item = index[id];
-
-			if (item.showChildren === true) {
-				// hide all children
-				item.showChildren = false;
-
-				function hide(parentId) {
-					var item = index[parentId];
-					item.children.forEach(function (child) {
-						if (child.showChildren !== undefined) {
-							child.showChildren = false;
-						}
-
-						$(child.el).closest("tr").addClass("tt-hide");
-						hide(child.id);
-					});
-				}
-
-				hide(id);
-				drawLines();
-			}
-			else {
-				// show direct children
-				item.showChildren = true;
-				item.children.forEach(function (child) {
-					$(child.el).closest("tr").removeClass("tt-hide");
-				});
-				drawLines();
-			}
-		});
-
-		// initially hide all children
-		items.forEach(function (item) {
-
-			if (item.parent === undefined && item.children.length > 0) {
-				item.el.find(".content").click();
-			}
-		});
-	}
+    }
 });
-


### PR DESCRIPTION
I'm new to JS/Jquery, but I created a loop to allow multiple tables to be painted using the $(".table").treetable(); selector. The previous master got confused if multiple tables were selected on the same page

Also fixed a problem where calling the plugin repeatedly would re-paint the content. I propose using the tt-table class to decide whether the tt-table has already been painted. 

Also, for people using the tt-table in tabs, where the table is not initially visible, the element.position() method won't work (returns top=0, left = 0) so in these cases I propose skipping the draw of the content. Later on the ".on('shown.bs.tab', function (e) {" event we can redraw the tables again