### PR TITLE
Fix formatting

### DIFF
--- a/jquery-treetable.js
+++ b/jquery-treetable.js
@@ -1,6 +1,17 @@
 jQuery.fn.extend({
 	treetable: function() {
-		var $table = $(this);
+		
+	//collection of all the tables selected
+	var $tables = $(this);
+
+	//loop through each table
+	for (i = 0; i < $tables.length; i++) {
+
+	//don't paint the tt if the table has already been painted or it's invisible
+	if (!$table.hasClass("tt-table") && $table.is(":visible")) {
+
+		var $table = $($tables[i]);	
+
 		$table.addClass("tt-table");
 
 		var $items = $table.find("div.tt");
@@ -133,8 +144,10 @@ jQuery.fn.extend({
 				drawLines();
 			}
 		});
+		};
+	}
 
-		// initially hide all children
+		// initially hide all children - we should provide an option to set behavior here
 		items.forEach(function (item) {
 
 			if (item.parent === undefined && item.children.length > 0) {


### PR DESCRIPTION
I'm new to JS/Jquery, but I created a loop to allow multiple tables to be painted using the $(".table").treetable(); selector. The previous master got confused if multiple tables were selected on the same page

Also fixed a problem where calling the plugin repeatedly would re-paint the content. I propose using the tt-table class to decide whether the tt-table has already been painted.

Also, for people using the tt-table in tabs, where the table is not initially visible, the element.position() method won't work (returns top=0, left = 0) so in these cases I propose skipping the draw of the content. Later on the ".on('shown.bs.tab', function (e) {" event we can redraw the tables again